### PR TITLE
Fixing error in case of empty guided tour results.

### DIFF
--- a/R/animate.r
+++ b/R/animate.r
@@ -97,7 +97,9 @@ animate <- function(data, tour_path = grand_tour(), display = display_xy(), star
     return()
   })
 
-  invisible(bases[, , seq_len(b)])
+  if (b != 0){
+    invisible(bases[, , seq_len(b)])
+  }
 }
 
 rstudio_gd <- function() identical(names(dev.cur()), "RStudioGD")

--- a/R/history.r
+++ b/R/history.r
@@ -58,6 +58,7 @@ save_history <- function(data, tour_path = grand_tour(), max_bases = 100, start 
     # An infinite step size forces the tour path to generate a new basis
     # every time, so no interpolation occurs.
     step <- tour(step_size)
+    if (is.null(step$target)) break # this can happen if no better basis is found in guided tour
 
     projs[, , i] <- step$target
     if (step$step < 0) break #already appended final projection, break directly
@@ -67,6 +68,7 @@ save_history <- function(data, tour_path = grand_tour(), max_bases = 100, start 
   # (e.g. guided tour)
   empty <- apply(projs, 3, function(x) all(is.na(x)))
   projs <- projs[, , !empty, drop = FALSE]
+  if (length(projs) == 0) return(NULL)
 
   attr(projs, "data") <- data
   structure(projs, class = "history_array")

--- a/R/tour.r
+++ b/R/tour.r
@@ -39,6 +39,9 @@ new_tour <- function(data, tour_path, start = NULL) {
     step <<- step + 1
     cur_dist <<- cur_dist + step_size
 
+    if (target_dist == 0 & step > 1){ # should only happen for guided tour when no better basis is found (relative to starting plane)
+      return(list(proj = proj, target = target, step = -1)) #use negative step size to signal that we have reached the final target
+    }
     # We're at (or past) the target, so generate a new one and reset counters
     if (step_size > 0 & is.finite(step_size) & cur_dist >= target_dist) {
       proj <<- geodesic$interpolate(1.) #make sure next starting plane is previous target


### PR DESCRIPTION
Changes catch errors that currently occur in case of unsuccessful guided tour (when no projection is found with higher index value than the starting plane).