### PR TITLE
Add option to set the size of points when plotting point clouds.

### DIFF
--- a/R/display-density2d.r
+++ b/R/display-density2d.r
@@ -10,7 +10,8 @@
 #'   If not set, defaults to maximum distance from origin to each row of data.
 #' @param edges A two column integer matrix giving indices of ends of lines.
 #' @param col color to be plotted.  Defaults to "black"
-#' @param pch size of the point to be plotted.  Defaults to 20.
+#' @param pch shape of the point to be plotted.  Defaults to 20.
+#' @param cex size of the point to be plotted.  Defaults to 1.
 #' @param contour_quartile Vector of quartiles to plot the contours at. Defaults to 5.
 #' @param ...  other arguments passed on to \code{\link{animate}} and
 #'   \code{\link{display_density2d}}
@@ -44,8 +45,8 @@
 #' animate(flea[, 1:6], grand_tour(),
 #'   display_density2d(axes = "bottomleft", edges = edges))
 display_density2d <- function(center = TRUE, axes = "center", half_range = NULL,
-                       col = "black", pch  = 20, contour_quartile = c(.25, .5, .75),
-                       edges = NULL, ...) {
+                       col = "black", pch  = 20, cex = 1,
+                       contour_quartile = c(.25, .5, .75), edges = NULL, ...) {
 
   labels <- NULL
   init <- function(data) {
@@ -93,7 +94,7 @@ display_density2d <- function(center = TRUE, axes = "center", half_range = NULL,
                 axes=FALSE, add=TRUE)
       }
     }
-    points(x, col = col, pch = pch)
+    points(x, col = col, pch = pch, cex = cex)
 
     if (!is.null(edges)) {
       segments(x[edges[,1], 1], x[edges[,1], 2],

--- a/R/display-groupxy.r
+++ b/R/display-groupxy.r
@@ -13,7 +13,8 @@
 #'   If not set, defaults to maximum distance from origin to each row of data.
 #' @param edges A two column integer matrix giving indices of ends of lines.
 #' @param col color to be plotted.  Defaults to "black"
-#' @param pch size of the point to be plotted.  Defaults to 20.
+#' @param pch shape of the point to be plotted.  Defaults to 20.
+#' @param cex size of the point to be plotted.  Defaults to 1.
 #' @param group_by variable to group by. Must have less than 25 unique values.
 #' @param plot_xgp if TRUE, plots points from other groups in light grey
 #' @param ...  other arguments passed on to \code{\link{animate}} and
@@ -27,7 +28,7 @@
 #' animate_groupxy(f, col = col, pch = pch, group_by = flea$species)
 #' animate_groupxy(f, col = col, pch = pch, group_by = flea$species, plot_xgp = FALSE)
 display_groupxy <- function(centr = TRUE, axes = "center", half_range = NULL,
-                            col = "black", pch  = 20, edges = NULL,
+                            col = "black", pch = 20, cex = 1, edges = NULL,
                             group_by = NULL, plot_xgp = TRUE, ...) {
   labels <- NULL
   init <- function(data) {
@@ -66,7 +67,7 @@ display_groupxy <- function(centr = TRUE, axes = "center", half_range = NULL,
     draw_tour_axes(proj, labels, limits = 1, axes)
 
     if (ngps < 2) {
-      points(x, col = col, pch = pch, new = FALSE)
+      points(x, col = col, pch = pch, cex = cex, new = FALSE)
       if (!is.null(edges)) {
           segments(x[edges[,1], 1], x[edges[,1], 2],
                x[edges[,2], 1], x[edges[,2], 2])
@@ -77,13 +78,15 @@ display_groupxy <- function(centr = TRUE, axes = "center", half_range = NULL,
         x.sub <- x[group_by == gps[i],]
         col.sub  <- if (length(col) == nrow(x)) col[group_by == gps[i]] else col
         pch.sub  <- if (length(pch) == nrow(x)) pch[group_by == gps[i]] else pch
+        cex.sub  <- if (length(cex) == nrow(x)) cex[group_by == gps[i]] else cex
 
         blank_plot(xlim = c(-1, 1), ylim = c(-1, 1))
         if (plot_xgp) {
           points(x[group_by != gps[i],], col = "#DEDEDEDE", new = FALSE,
-            pch = if (length(pch) >1) pch[group_by != gps[i]] else pch)
+            pch = if (length(pch) > 1) pch[group_by != gps[i]] else pch,
+            cex = if (length(cex) > 1) cex[group_by != gps[i]] else cex)
         }
-        points(x.sub, col = col.sub, pch = pch.sub, new = FALSE)
+        points(x.sub, col = col.sub, pch = pch.sub, cex = cex.sub,  new = FALSE)
 
         if (!is.null(edges)) {
           segments(x[edges[group_by == gps[i],1], 1], x[edges[group_by == gps[i],1], 2],

--- a/R/display-slice.r
+++ b/R/display-slice.r
@@ -15,6 +15,8 @@
 #'   Defaults to 20.
 #' @param pch_other marker for plotting points outside the slice.
 #'   Defaults to 46.
+#' @param cex_slice size of the points inside the slice. Defaults to 2.
+#' @param cex_other size if the points outside the slice. Defaults to 1.
 #' @param eps volume of the slice. If not set, suggested value is caluclated and
 #'   printed to the screen.
 #' @param anchor A vector specifying the reference point to anchor the slice.
@@ -45,8 +47,9 @@
 
 
 display_slice <- function(center = TRUE, axes = "center", half_range = NULL,
-                             col = "black", pch_slice  = 20, pch_other = 46, eps = NULL,
-                             anchor = NULL, edges = NULL, edges.col = "black",...) {
+                          col = "black", pch_slice  = 20, pch_other = 46,
+                          cex_slice = 2, cex_other = 1, eps = NULL,
+                          anchor = NULL, edges = NULL, edges.col = "black", ...) {
 
   labels <- NULL
   h <- NULL
@@ -82,9 +85,11 @@ display_slice <- function(center = TRUE, axes = "center", half_range = NULL,
     d <- anchored_orthogonal_distance(proj, data, anchor)
     pch <- rep(pch_other, nrow(x))
     pch[d < h] <- pch_slice
+    cex <- rep(cex_other, nrow(x))
+    cex[d < h] <- cex_slice
     if (center) x <- center(x)
     x <- x / half_range
-    points(x, col = col, pch = pch)
+    points(x, col = col, pch = pch, cex = cex)
 
     if (!is.null(edges)) {
       segments(x[edges[,1], 1], x[edges[,1], 2],

--- a/R/display-stereo.r
+++ b/R/display-stereo.r
@@ -3,12 +3,13 @@
 #' @param d3 3d numeric matrix giving position of points
 #' @param blue blue colour (for right eye)
 #' @param red red colour (for left eye)
+#' @param cex size of the point to be plotted.  Defaults to 1.
 #' @keywords internal
-anaglyph <- function(d3, blue, red) {
+anaglyph <- function(d3, blue, red, cex = 1) {
   d2 <- project3d(d3)
 
-  with(d2, points(right, y, col=blue, pch = 20))
-  with(d2, points(left, y, col=red, pch=20))
+  with(d2, points(right, y, col = blue, pch = 20, cex = cex))
+  with(d2, points(left , y, col = red , pch = 20, cex = cex))
 }
 
 #' Stereographic projection
@@ -42,12 +43,13 @@ project3d <- function(d3, length = par("din")[1] * 25.4, z0 = 300, d = 30) {
 #'
 #' @param blue blue colour (for right eye)
 #' @param red red colour (for left eye)
+#' @param cex size of the point to be plotted.  Defaults to 1.
 #' @param ... other arguments passed on to \code{\link{animate}}
 #' @keywords hplot
 #' @export
 #' @examples
 #' animate_stereo(flea[, 1:6])
-display_stereo <- function(blue, red, ...)
+display_stereo <- function(blue, red, cex = 1, ...)
 {
 
   labels <- NULL
@@ -63,7 +65,7 @@ display_stereo <- function(blue, red, ...)
   }
   render_data <- function(data, proj, geodesic) {
     render_frame()
-    anaglyph(data %*% proj, blue, red)
+    anaglyph(data %*% proj, blue, red, cex = cex)
 
     axes <- project3d(proj)
     with(axes, {

--- a/R/display-trails.r
+++ b/R/display-trails.r
@@ -9,13 +9,13 @@
 #' @param half_range half range to use when calculating limits of projected.
 #'   If not set, defaults to maximum distance from origin to each row of data.
 #' @param col color to be plotted.  Defaults to "black"
-#' @param pch size of the point to be plotted.  Defaults to 20.
+#' @param pch shape of the point to be plotted.  Defaults to 20.
 #' @param past draw line between current projection and projection \code{past}
 #'   steps ago
 #' @param ...  other arguments passed on to \code{\link{animate}} and
 #'   \code{\link{display_xy}}
 #' @export
-display_trails <- function(center = TRUE, axes = "center", half_range = NULL, col = "black", pch  = 20, past = 3, ...) {
+display_trails <- function(center = TRUE, axes = "center", half_range = NULL, col = "black", pch  = 20, cex = 1, past = 3, ...) {
 
   # Inherit most behaviour from display_xy.  This is a little hacky, but
   # the only way until tourr switch to a proper object system.

--- a/R/display-xy.r
+++ b/R/display-xy.r
@@ -10,7 +10,8 @@
 #'   If not set, defaults to maximum distance from origin to each row of data.
 #' @param edges A two column integer matrix giving indices of ends of lines.
 #' @param col color to be plotted.  Defaults to "black"
-#' @param pch size of the point to be plotted.  Defaults to 20.
+#' @param pch shape of the point to be plotted.  Defaults to 20.
+#' @param cex size of the point to be plotted.  Defaults to 1.
 #' @param edges.col colour of edges to be plotted, Defaults to "black"
 #' @param ...  other arguments passed on to \code{\link{animate}} and
 #'   \code{\link{display_xy}}
@@ -40,7 +41,7 @@
 #' edges <- matrix(c(1:5, 2:6), ncol = 2)
 #' animate(flea[, 1:6], grand_tour(),
 #'   display_xy(axes = "bottomleft", edges = edges))
-display_xy <- function(center = TRUE, axes = "center", half_range = NULL, col = "black", pch  = 20, edges = NULL, edges.col = "black", ...) {
+display_xy <- function(center = TRUE, axes = "center", half_range = NULL, col = "black", pch = 20, cex = 1, edges = NULL, edges.col = "black", ...) {
 
   labels <- NULL
   init <- function(data) {
@@ -68,7 +69,7 @@ display_xy <- function(center = TRUE, axes = "center", half_range = NULL, col = 
     x <- data %*% proj
     if (center) x <- center(x)
     x <- x / half_range
-    points(x, col = col, pch = pch)
+    points(x, col = col, pch = pch, cex = cex)
 
     if (!is.null(edges)) {
       segments(x[edges[,1], 1], x[edges[,1], 2],


### PR DESCRIPTION
The `pch` option of function `points()` was used and documented as a parameter to handle the size of points, while it handles shape. I modified this and added the `cex` parameter in all functions displaying `points()` where the `cex` parameter had not been set already to some specific value.