### PR TITLE
only initialise `tries` if guided tour

### DIFF
--- a/R/geodesic-path.r
+++ b/R/geodesic-path.r
@@ -20,25 +20,28 @@
 #' @export
 #' @keywords internal
 new_geodesic_path <- function(name, generator, frozen = NULL, ...) {
-  #  FIXME: why is verbose being reset?
   tour_path <- function(current, data, ...) {
     #browser()
     if (is.null(current)) {
+      if (name == "guided") tries <<- 0
       return(generator(NULL, data, ...))
     }
 
     # Keep trying until we get a frame that's not too close to the
     # current frame
-    dist <- 0; tries <<- tries + 1
+    dist <- 0
     while (dist < 1e-3) {
+
+      if(name == "guided") tries <<- tries + 1
+
       target <- generator(current, data, ...)
 
       # generator has run out, so give up
       if (is.null(target)) return(NULL)
 
-      tries <- tries + 1
       # give up, generator produced 10 equivalent frames in a row
-      if (tries > 10) return(NULL)
+
+      if (name == "guided") if (tries > 10) return(NULL)
 
       dist <- proj_dist(current, target)
 

--- a/R/tour-guided.r
+++ b/R/tour-guided.r
@@ -59,7 +59,6 @@ guided_tour <- function(index_f, d = 2, alpha = 0.5, cooling = 0.99, max.tries =
                                   info = "start",
                                   loop = NA)
       }
-      tries <<-0
 
       return(current)
     }


### PR DESCRIPTION
fix the initialisation of `tries`. 

It seems to me that the grand_tour animation will always keep running: `animate_xy(flea[,1:6])`. Do you want to confirm if it works as it is supposed to?