### PR TITLE
fix issue #114

### DIFF
--- a/R/render.r
+++ b/R/render.r
@@ -123,6 +123,11 @@ render_gif <- function(data, tour_path, display, gif_file = "animation.gif", ...
 
   png_files <- sprintf(png_path, 1:frames)
   on.exit(unlink(png_files))
-
+  png_exist <- sapply(png_files, file.exists)
+  if (!all(png_exist)){
+    n_png <- sum(png_exist)
+    warning(paste0("Note: only ", n_png, " frames generated, argument frames = ", frames, " is ignored."))
+  }
+  png_files <- png_files[png_exist]
   gifski::gifski(png_files, gif_file, delay = apf, progress = TRUE)
 }


### PR DESCRIPTION
The pull request adds a check on whether all the `png_files` exist. If not, only the generated pngs are used to render the gif and a warning is emitted. 

``` r
library(tourr)
set.seed(123)
gif_file <- file.path(tempdir(), "test.gif")
tourr::render_gif(
  flea[1:6],
  tour_path = guided_tour(holes()),
  display = display_xy(),
  frames = 70,
  gif_file = gif_file
)
#> Converting input data to the required matrix format.
#> Value  0.538   43.4 % better  - NEW BASIS
#> Using half_range 0.98
#> Value  0.730   35.6 % better  - NEW BASIS
#> Value  0.780   6.8 % better  - NEW BASIS
#> Value  0.846   8.5 % better  - NEW BASIS
#> Value  0.872   3.2 % better  - NEW BASIS
#> Value  0.883   1.3 % better  - NEW BASIS
#> Value  0.887   0.4 % better  - NEW BASIS
#> Value  0.891   0.5 % better  - NEW BASIS
#> Value  0.897   0.7 % better  - NEW BASIS
#> Value  0.903   0.7 % better  - NEW BASIS
#> Value  0.906   0.3 % better  - NEW BASIS
#> Value  0.906   0.0 % better 
#> Value  0.910   0.5 % better  - NEW BASIS
#> Value  0.910   0.0 % better 
#> Value  0.912   0.3 % better  - NEW BASIS
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.1 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.1 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.1 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.1 % better 
#> Value  0.913   0.0 % better 
#> Value  0.913   0.0 % better 
#> No better bases found after 25 tries.  Giving up.
#> Final projection: 
#> 0.333  0.486  
#> 0.338  -0.344  
#> 0.412  -0.189  
#> 0.381  -0.337  
#> 0.467  0.644  
#> 0.492  -0.285
#> Warning in tourr::render_gif(flea[1:6], tour_path = guided_tour(holes()), :
#> Note: only 60 frames generated, argument frames = 70 is ignored.
#> [1] "/var/folders/_t/v9kjp3yn2k73wm16y_jlphgsbbd6_6/T//Rtmp8MXzWn/test.gif"
```

<sup>Created on 2022-10-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>